### PR TITLE
feat: update supported browsers, add npm script to list browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,40 +1,54 @@
 # `@edx/browserslist-config`
 
-[![license](https://img.shields.io/npm/l/@edx/browserslist-config)](LICENSE)
+[![license](https://img.shields.io/npm/l/@edx/browserslist-config)](LICENSE) [![npm](https://img.shields.io/npm/v/@edx/browserslist-config)](https://www.npmjs.com/package/@edx/browserslist-config)
 
-Shareable [browserslist](https://github.com/browserslist/browserslist) configuration for edX. See [documentation](https://github.com/browserslist/browserslist#shareable-configs) on shareable `browserslist` configurations for more details.
+Shareable [browserslist](https://github.com/browserslist/browserslist) configuration for Open edX. If our supported browsers changes in the future, this will be the primary place to update for all consumers (e.g., micro-frontends).
+
+## What is Browserslist?
+
+[Browserslist](https://github.com/browserslist/browserslist) is a tool to share target browsers and Node.js versions between different frontend tools (e.g., autoprefixer, babel, etc.).
+
+See [documentation](https://github.com/browserslist/browserslist#shareable-configs) on shareable `browserslist` configurations for more details.
 
 ## Supported Browsers
+
+### Desktop
 
 | Browser                       | Version |
 | ----------------------------- | ------- |
 | Chrome                        | last 2  |
-| Chrome for Android            | last 2  |
 | Safari                        | last 2  |
-| Safari for iOS                | last 2  |
 | Edge                          | last 2  |
 | Firefox                       | last 2  |
-| Firefox for Android           | last 2  |
+
+### Mobile
+
+| Browser                       | Version |
+| ----------------------------- | ------- |
+| Chrome for Android            | last 3  |
+| Safari for iOS                | last 3  |
+| Firefox for Android           | last 3  |
+
+### List all supported browsers
 
 You can list all supported browsers by running:
 
 ```shell
-$ npx browserslist "last 2 chrome versions, last 2 safari versions, last 2 edge versions, last 2 firefox versions, last 2 chromeandroid versions, last 2 firefoxandroid versions, last 2 ios versions"
+npm install
+npm run supported
 ```
 
 Learn more by visiting the [browser support page on the edX Support Portal](https://support.edx.org/hc/en-us/articles/206211848-What-are-the-system-requirements-and-supported-browsers-on-edX-).
 
-## Installation
+## Installation and usage
 
-Install the module.
+Install the package in your repository:
 
 ```shell
 $ npm install -D @edx/browserslist-config
 ```
 
-## Usage
-
-### package.json
+In your `package.json` file:
 
 ```json
 {

--- a/index.js
+++ b/index.js
@@ -1,10 +1,16 @@
-module.exports = [
-  'last 2 chrome versions',
-  'last 2 safari versions',
-  'last 2 edge versions',
-  'last 2 firefox versions',
-  // Mobile
-  'last 2 chromeandroid versions',
-  'last 2 firefoxandroid versions',
-  'last 2 ios versions',
+const desktop = [
+  'last 2 Chrome major versions',
+  'last 2 Firefox major versions',
+  'last 2 Safari major versions',
+  'last 2 Edge major versions',
 ];
+
+const mobile = [
+  'last 3 ChromeAndroid major versions',
+  'last 3 FirefoxAndroid major versions',
+  'last 3 iOS major versions',
+];
+
+const supportedBrowsers = desktop.concat(mobile);
+
+module.exports = supportedBrowsers;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "@edx/browserslist-config",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "browserslist": {
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001332",
+        "electron-to-chromium": "^1.4.118",
+        "escalade": "^3.1.1",
+        "node-releases": "^2.0.3",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001342",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz",
+      "integrity": "sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA==",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.4.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
+      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,5 +15,14 @@
   },
   "bugs": {
     "url": "https://github.com/edx/browserslist-config/issues"
+  },
+  "files": [
+    "index.js"
+  ],
+  "scripts": {
+    "supported": "node -e \"var bl = require('browserslist'); console.log(bl(require('./index')).join('\\n'));\""
+  },
+  "devDependencies": {
+    "browserslist": "4.20.3"
   }
 }


### PR DESCRIPTION
# Description

* Separates desktop/mobile browser lists and concatenates them together.
* Updates to `README`
* Add `supported` NPM script to preview which browsers are supported with the config (i.e., `npm run supported`)