### PR TITLE
Update our browserslist config per "Best Practices"

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,8 @@ const mobile = [
 // adding these is strongly recommended by browserslist, so we do so:
 // https://github.com/browserslist/browserslist?tab=readme-ov-file#best-practices
 const bestPractices = [
-  'last 2 versions',
-  'not dead',
-  '> 0.2%',
+  'last 2 versions and not dead',
+  '> 0.2% and not dead',
 ];
 
 module.exports = [

--- a/index.js
+++ b/index.js
@@ -11,6 +11,17 @@ const mobile = [
   'last 3 iOS major versions',
 ];
 
-const supportedBrowsers = desktop.concat(mobile);
+// Other browsers are not officially supported by Open edX, but
+// adding these is strongly recommended by browserslist, so we do so:
+// https://github.com/browserslist/browserslist?tab=readme-ov-file#best-practices
+const bestPractices = [
+  'last 2 versions',
+  'not dead',
+  '> 0.2%',
+];
 
-module.exports = supportedBrowsers;
+module.exports = [
+  ...desktop,
+  ...mobile,
+  ...bestPractices,
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "AGPL-3.0",
       "devDependencies": {
-        "browserslist": "4.20.3"
+        "browserslist": "4.24.2"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "dev": true,
       "funding": [
         {
@@ -25,14 +25,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001332",
-        "electron-to-chromium": "^1.4.118",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.3",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -42,9 +45,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001660",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
-      "integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
+      "version": "1.0.30001684",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001684.tgz",
+      "integrity": "sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ==",
       "dev": true,
       "funding": [
         {
@@ -62,9 +65,9 @@
       ]
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.22",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.22.tgz",
-      "integrity": "sha512-tKYm5YHPU1djz0O+CGJ+oJIvimtsCcwR2Z9w7Skh08lUdyzXY5djods3q+z2JkWdb7tCcmM//eVavSRAiaPRNg==",
+      "version": "1.5.67",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.67.tgz",
+      "integrity": "sha512-nz88NNBsD7kQSAGGJyp8hS6xSPtWwqNogA0mjtc2nUYeEf3nURK9qpV18TuBdDmEDgVWotS8Wkzf+V52dSQ/LQ==",
       "dev": true
     },
     "node_modules/escalade": {
@@ -83,10 +86,40 @@
       "dev": true
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edx/browserslist-config",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@edx/browserslist-config",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "license": "AGPL-3.0",
       "devDependencies": {
         "browserslist": "4.24.2"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "supported": "node -e \"var bl = require('browserslist'); console.log(bl(require('./index')).join('\\n'));\""
   },
   "devDependencies": {
-    "browserslist": "4.20.3"
+    "browserslist": "4.24.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/browserslist-config",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "description": "Shared browserslist config for Open edX",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Our browserslist config is currently not following the [Best Practices](https://github.com/browserslist/browserslist?tab=readme-ov-file#best-practices) that the browserslist project recommends.

In particular, they say:

> Don’t remove browsers just because you don’t know them. Opera Mini has 100 million users in Africa and it is more popular in the global market than Microsoft Edge. Chinese QQ Browsers has more market share than Firefox and desktop Safari combined.

Here is the list of supported browsers (from `npm run supported`), before and after this change:

```diff
 and_chr 131
 and_ff 132
+and_qq 14.9
+and_uc 15.5
+android 131
 chrome 131
 chrome 130
+chrome 129
+chrome 128
+chrome 127
+chrome 126
+chrome 125
+chrome 124
+chrome 109
 edge 131
 edge 130
+edge 129
+edge 128
 firefox 132
 firefox 131
+firefox 130
+firefox 129
+firefox 115
 ios_saf 18.1
 ios_saf 18.0
 ios_saf 17.6-17.7
 ios_saf 17.5
 ios_saf 17.4
 ios_saf 17.3
 ios_saf 17.2
 ios_saf 17.1
 ios_saf 17.0
 ios_saf 16.6-16.7
 ios_saf 16.5
 ios_saf 16.4
 ios_saf 16.3
 ios_saf 16.2
 ios_saf 16.1
 ios_saf 16.0
+ios_saf 15.6-15.8
+kaios 3.0-3.1
+kaios 2.5
+op_mini all
+op_mob 80
+opera 114
+opera 113
+opera 112
 safari 18.1
 safari 18.0
 safari 17.6
 safari 17.5
 safari 17.4
 safari 17.3
 safari 17.2
 safari 17.1
 safari 17.0
+safari 16.6
+safari 15.6
+samsung 26
+samsung 25
```

I don't have a strong opinion on this change, but I do think it makes sense to follow the best practices if there's little or no cost to doing so.